### PR TITLE
refactor: `async_setup_platforms` -> `async_forward_entry_setups`

### DIFF
--- a/custom_components/auto_backup/__init__.py
+++ b/custom_components/auto_backup/__init__.py
@@ -189,7 +189,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     for service, schema in MAP_SERVICES.items():
         hass.services.async_register(DOMAIN, service, async_service_handler, schema)
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 


### PR DESCRIPTION
Address https://github.com/jcwillox/hass-auto-backup/issues/83

"Detected integration that called async_setup_platforms instead of awaiting async_forward_entry_setups; this will fail in version 2023.3. Please report issue to the custom integration author for auto_backup using this method at custom_components/auto_backup/init.py, line 192: hass.config_entries.async_setup_platforms(entry, PLATFORMS)"

See https://developers.home-assistant.io/blog/2022/07/08/config_entry_forwards/