### PR TITLE
Avoid deprecated types

### DIFF
--- a/custom_components/auto_backup/__init__.py
+++ b/custom_components/auto_backup/__init__.py
@@ -17,12 +17,11 @@ from homeassistant.components.hassio import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_NAME, __version__
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.json import JSONEncoder
 from homeassistant.helpers.storage import Store
-from homeassistant.helpers.typing import HomeAssistantType, ServiceCallType
 from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util
 from slugify import slugify
@@ -167,7 +166,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     await auto_backup.load_snapshots_expiry()
 
     ### REGISTER SERVICES ###
-    async def async_service_handler(call: ServiceCallType):
+    async def async_service_handler(call: ServiceCall):
         """Handle Auto Backup service calls."""
         if call.service == SERVICE_PURGE:
             await auto_backup.purge_backups()
@@ -208,7 +207,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 
 class AutoBackup:
-    def __init__(self, hass: HomeAssistantType, options: Dict, handler: HandlerBase):
+    def __init__(self, hass: HomeAssistant, options: Dict, handler: HandlerBase):
         self._hass = hass
         self._handler = handler
         self._auto_purge = options[CONF_AUTO_PURGE]

--- a/custom_components/auto_backup/__init__.py
+++ b/custom_components/auto_backup/__init__.py
@@ -1,4 +1,5 @@
 """Component to create and automatically remove Home Assistant backups."""
+
 import logging
 from datetime import datetime, timedelta, timezone
 from fnmatch import fnmatchcase

--- a/custom_components/auto_backup/config_flow.py
+++ b/custom_components/auto_backup/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Auto Backup integration."""
+
 import logging
 
 import voluptuous as vol

--- a/custom_components/auto_backup/sensor.py
+++ b/custom_components/auto_backup/sensor.py
@@ -1,11 +1,10 @@
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_NAME
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback, Event
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import HomeAssistantType, EventType
 
 from . import AutoBackup
 from .const import (
@@ -23,7 +22,7 @@ ATTR_MONITORED = "monitored_backups"
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
     """Set up Auto Backup sensors based on a config entry."""
     auto_backup = hass.data[DOMAIN][DATA_AUTO_BACKUP]
@@ -61,7 +60,7 @@ class AutoBackupSensor(SensorEntity):
             self.async_schedule_update_ha_state(True)
 
         @callback
-        def backup_failed(event_: EventType):
+        def backup_failed(event_: Event):
             """Store last failed and update sensor"""
             self._attr_extra_state_attributes[ATTR_LAST_FAILURE] = event_.data.get(
                 ATTR_NAME


### PR DESCRIPTION
Fixes #129

Avoid deprecated types:
```
HomeAssistantType was used from auto_backup, this is a deprecated alias which will be removed in HA Core 2025.5. Use homeassistant.core.HomeAssistant instead, please report it to the author of the 'auto_backup' custom integration
ServiceCallType was used from auto_backup, this is a deprecated alias which will be removed in HA Core 2025.5. Use homeassistant.core.ServiceCall instead, please report it to the author of the 'auto_backup' custom integration
EventType was used from auto_backup, this is a deprecated alias which will be removed in HA Core 2025.5. Use homeassistant.core.Event instead, please report it to the author of the 'auto_backup' custom integration
```

Works with HA 2024.5.3