### PR TITLE
fix: replace deprecated `is_hassio` method in HA 2024.11

### DIFF
--- a/custom_components/auto_backup/__init__.py
+++ b/custom_components/auto_backup/__init__.py
@@ -14,13 +14,13 @@ from homeassistant.components.hassio import (
     ATTR_FOLDERS,
     ATTR_ADDONS,
     ATTR_PASSWORD,
-    is_hassio,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_NAME, __version__
 from homeassistant.core import HomeAssistant, callback, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.hassio import is_hassio
 from homeassistant.helpers.json import JSONEncoder
 from homeassistant.helpers.storage import Store
 from homeassistant.loader import bind_hass

--- a/custom_components/auto_backup/config_flow.py
+++ b/custom_components/auto_backup/config_flow.py
@@ -4,8 +4,8 @@ import logging
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.components.hassio import is_hassio
 from homeassistant.core import callback, HomeAssistant
+from homeassistant.helpers.hassio import is_hassio
 
 from . import is_backup
 from .const import DOMAIN, DEFAULT_BACKUP_TIMEOUT, CONF_AUTO_PURGE, CONF_BACKUP_TIMEOUT

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "zip_release": true,
   "hide_default_branch": true,
   "filename": "auto_backup.zip",
-  "homeassistant": "2023.4.0"
+  "homeassistant": "2024.11.0"
 }


### PR DESCRIPTION
Fixes: #163, #158

Requires pinning minimum HA version to 2024.11.0

Related: https://github.com/home-assistant/core/pull/127228