### PR TITLE
fix: deprecation of manual config entry assignment in 2024.12.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ cython_debug/
 .idea/
 .devcontainer/config/*
 !.devcontainer/config/configuration.yaml
+
+# MacOS
+.DS_Store

--- a/custom_components/auto_backup/config_flow.py
+++ b/custom_components/auto_backup/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Auto Backup integration."""
 
 import logging
-
+from typing import Any
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback, HomeAssistant
@@ -39,33 +39,26 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
+
+
+OPTIONS_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_AUTO_PURGE, default=True): bool,
+        vol.Required(CONF_BACKUP_TIMEOUT, default=DEFAULT_BACKUP_TIMEOUT): int,
+    }
+)
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
-    def __init__(self, config_entry):
-        """Initialize Auto Backup options flow."""
-        self.config_entry = config_entry
-
-    async def async_step_init(self, user_input=None):
+    async def async_step_init(self, user_input: dict[str, Any] | None = None):
         """Manage the Auto Backup options."""
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            return self.async_create_entry(data=user_input)
 
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_AUTO_PURGE,
-                        default=self.config_entry.options.get(CONF_AUTO_PURGE, True),
-                    ): bool,
-                    vol.Required(
-                        CONF_BACKUP_TIMEOUT,
-                        default=self.config_entry.options.get(
-                            CONF_BACKUP_TIMEOUT, DEFAULT_BACKUP_TIMEOUT
-                        ),
-                    ): int,
-                }
+            data_schema=self.add_suggested_values_to_schema(
+                OPTIONS_SCHEMA, self.config_entry.options
             ),
         )

--- a/custom_components/auto_backup/config_flow.py
+++ b/custom_components/auto_backup/config_flow.py
@@ -45,7 +45,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class OptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry):
         """Initialize Auto Backup options flow."""
-        self.config_entry: config_entries.ConfigEntry = config_entry
+        self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         """Manage the Auto Backup options."""


### PR DESCRIPTION
### Summary
This PR addresses the deprecation warning caused by the use of `self.config_entry: config_entries.ConfigEntry = config_entry` in `config_flow.py`.

### Changes
- Replaced explicit type annotation with `self.config_entry = config_entry`.
- Resolves compatibility issues with Home Assistant 2025.12.

### Testing
- Warning no longer appears in logs.
- Integration functions as expected.

### Reference
- [Home Assistant Developer Documentation](https://developers.home-assistant.io/)
