### PR TITLE
feat: Make on-disk filename same as name in supervised installations

### DIFF
--- a/custom_components/auto_backup/const.py
+++ b/custom_components/auto_backup/const.py
@@ -43,6 +43,7 @@ ATTR_PURGEABLE = "purgeable_backups"
 ATTR_MONITORED = "monitored_backups"
 ATTR_ERROR = "error"
 ATTR_SLUG = "slug"
+ATTR_FILENAME = "filename"
 
 DEFAULT_BACKUP_FOLDERS = {
     "ssl": "ssl",

--- a/custom_components/auto_backup/manager.py
+++ b/custom_components/auto_backup/manager.py
@@ -38,6 +38,7 @@ from .const import (
     ATTR_DOWNLOAD_PATH,
     ATTR_ENCRYPTED,
     ATTR_EXCLUDE_DATABASE,
+    ATTR_FILENAME,
 )
 from .handlers import HassioAPIError, HandlerBase
 
@@ -237,6 +238,10 @@ class AutoBackup:
             del data[ATTR_ENCRYPTED]
         elif ATTR_ENCRYPTED in data:
             del data[ATTR_ENCRYPTED]
+
+        # Add on-disk filename if supervised
+        if self._supervised:
+            data[ATTR_FILENAME] = data[ATTR_NAME] + ".tar"
 
         ### LOG DEBUG INFO ###
         # ensure password is scrubbed from logs


### PR DESCRIPTION
Tested on HAOS. Naming should already work fine for core installation.