### PR TITLE
fix: missing imports error on HA 2026.5.0

### DIFF
--- a/custom_components/auto_backup/__init__.py
+++ b/custom_components/auto_backup/__init__.py
@@ -6,11 +6,18 @@ from os import getenv
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components.backup.const import DATA_MANAGER
-from homeassistant.components.hassio.const import (
-    ATTR_FOLDERS,
-    ATTR_ADDONS,
-    ATTR_PASSWORD,
-)
+try:
+    from homeassistant.components.hassio.const import (  # HA 2026.5+
+        ATTR_FOLDERS,
+        ATTR_ADDONS,
+        ATTR_PASSWORD,
+    )
+except ImportError:
+    from homeassistant.components.hassio import (  # HA < 2026.5
+        ATTR_FOLDERS,
+        ATTR_ADDONS,
+        ATTR_PASSWORD,
+    )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_NAME, Platform
 from homeassistant.core import HomeAssistant, ServiceCall

--- a/custom_components/auto_backup/__init__.py
+++ b/custom_components/auto_backup/__init__.py
@@ -6,7 +6,7 @@ from os import getenv
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components.backup.const import DATA_MANAGER
-from homeassistant.components.hassio import (
+from homeassistant.components.hassio.const import (
     ATTR_FOLDERS,
     ATTR_ADDONS,
     ATTR_PASSWORD,

--- a/custom_components/auto_backup/handlers.py
+++ b/custom_components/auto_backup/handlers.py
@@ -10,7 +10,7 @@ import aiofiles
 import aiohttp
 from aiohttp.hdrs import AUTHORIZATION
 from homeassistant.components.backup.manager import BackupManager
-from homeassistant.components.hassio import (
+from homeassistant.components.hassio.const import (
     ATTR_PASSWORD,
     ATTR_HOMEASSISTANT_EXCLUDE_DATABASE,
 )

--- a/custom_components/auto_backup/handlers.py
+++ b/custom_components/auto_backup/handlers.py
@@ -10,10 +10,16 @@ import aiofiles
 import aiohttp
 from aiohttp.hdrs import AUTHORIZATION
 from homeassistant.components.backup.manager import BackupManager
-from homeassistant.components.hassio.const import (
-    ATTR_PASSWORD,
-    ATTR_HOMEASSISTANT_EXCLUDE_DATABASE,
-)
+try:
+    from homeassistant.components.hassio.const import (  # HA 2026.5+
+        ATTR_PASSWORD,
+        ATTR_HOMEASSISTANT_EXCLUDE_DATABASE,
+    )
+except ImportError:
+    from homeassistant.components.hassio import (  # HA < 2026.5
+        ATTR_PASSWORD,
+        ATTR_HOMEASSISTANT_EXCLUDE_DATABASE,
+    )
 from homeassistant.const import ATTR_NAME
 from homeassistant.core import HomeAssistant
 

--- a/custom_components/auto_backup/manager.py
+++ b/custom_components/auto_backup/manager.py
@@ -5,7 +5,7 @@ from os.path import join, isfile
 from typing import List, Dict, Tuple, Optional
 
 from homeassistant.components.backup.manager import DATA_MANAGER
-from homeassistant.components.hassio import (
+from homeassistant.components.hassio.const import (
     ATTR_FOLDERS,
     ATTR_ADDONS,
     ATTR_PASSWORD,

--- a/custom_components/auto_backup/manager.py
+++ b/custom_components/auto_backup/manager.py
@@ -5,12 +5,20 @@ from os.path import join, isfile
 from typing import List, Dict, Tuple, Optional
 
 from homeassistant.components.backup.manager import DATA_MANAGER
-from homeassistant.components.hassio.const import (
-    ATTR_FOLDERS,
-    ATTR_ADDONS,
-    ATTR_PASSWORD,
-    ATTR_HOMEASSISTANT_EXCLUDE_DATABASE,
-)
+try:
+    from homeassistant.components.hassio.const import (  # HA 2026.5+
+        ATTR_FOLDERS,
+        ATTR_ADDONS,
+        ATTR_PASSWORD,
+        ATTR_HOMEASSISTANT_EXCLUDE_DATABASE,
+    )
+except ImportError:
+    from homeassistant.components.hassio import (  # HA < 2026.5
+        ATTR_FOLDERS,
+        ATTR_ADDONS,
+        ATTR_PASSWORD,
+        ATTR_HOMEASSISTANT_EXCLUDE_DATABASE,
+    )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_NAME, __version__
 from homeassistant.core import HomeAssistant


### PR DESCRIPTION
## Problem

Home Assistant 2026.5.0 removed `ATTR_FOLDERS`, `ATTR_ADDONS`, `ATTR_PASSWORD`, and `ATTR_HOMEASSISTANT_EXCLUDE_DATABASE` from `homeassistant.components.hassio` (the `__init__` module). This causes `auto_backup` to fail at startup with:

```
Setup failed for custom integration 'auto_backup': Unable to import component: cannot import name 'ATTR_FOLDERS' from 'homeassistant.components.hassio'
```

This affects any user who upgrades to HA 2026.5.0. Reported in #221, #222, #223.

## Fix

These constants still exist in `homeassistant.components.hassio.const` (they have always been defined there and were previously re-exported from `__init__`). Change the import source from `homeassistant.components.hassio` to `homeassistant.components.hassio.const` in the three affected files.

## Files changed

- `custom_components/auto_backup/__init__.py`
- `custom_components/auto_backup/manager.py`
- `custom_components/auto_backup/handlers.py`

Closes #221, closes #222, closes #223